### PR TITLE
Add version range to worker nuget packages

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="[4.2.1,5)" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[1.4.0,2)" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.0-alpha.624" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />


### PR DESCRIPTION
Adding a version range to the Azure worker funktions packages to limit the dependencies to the current major version.