### PR TITLE
Configure correct main branch

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 assembly-versioning-scheme: Major
 branches:
-  master:
+  main:
     mode: ContinuousDeployment
     tag: alpha
     increment: Minor


### PR DESCRIPTION
This will probably cause issues with repo-sync, either forcing us to ignore repo-sync for this file or changing renaming the main branch to master to align with the automatically synced settings.