### PR TITLE
Revert update of Microsoft.CodeAnalysis.CSharp

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
-    <PropertyGroup>
-        <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
-    </PropertyGroup>
-    
+  <PropertyGroup>
+    <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
+  </PropertyGroup>
+
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/.editorconfig
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/.editorconfig
@@ -1,4 +1,3 @@
- 
 [*.cs]
 
 # Justification: Test project

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests.csproj
@@ -7,21 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.Worker.ServiceBus\NServiceBus.AzureFunctions.Worker.ServiceBus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.Worker.ServiceBus\NServiceBus.AzureFunctions.Worker.ServiceBus.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <NoWarn>$(NoWarn);PS0018</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="[4.2.1,5)" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[1.4.0,2)" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.0-alpha.624" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
-    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
+    <ProjectReference Include="..\NServiceBus.AzureFunctions.Worker.SourceGenerator\NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NServiceBus.AzureFunctions.Worker.SourceGenerator\NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj" ReferenceOutputAssembly="false" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="[4.2.1, 5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="[1.4.0, 2.0.0)" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.0-alpha.624" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
+    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="AddSourceGeneratorToPackage" BeforeTargets="_GetPackageFiles">
@@ -26,7 +26,7 @@
   </Target>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="NServiceBus.AzureFunctions.Worker.ServiceBus.Tests" Key="00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5" />
+    <InternalsVisibleTo Include="NServiceBus.AzureFunctions.Worker.ServiceBus.Tests" Key="$(NServiceBusTestsKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests.csproj
@@ -12,13 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <!-- Avoid updating this packages as this might cause the code generator to fail to load on projects using older .NET SDKs / Visual Studio -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests" Key="00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5" />
+    <InternalsVisibleTo Include="NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests" Key="$(NServiceBusTestsKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Avoid updating this packages as this might cause the code generator to fail to load on projects using older .NET SDKs / Visual Studio -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />


### PR DESCRIPTION
I noticed that the reference to `Microsoft.CodeAnalysis.CSharp` was updated by dependabot, which requires a newer version of the .NET SDK to be available in order to be able to load the source generator. If this code generator is then used on a project using an SDK older than 5.0.400, it will fail to load and generate the trigger code. The reverted version is the same as on the current 1.0 release branch.

Also added a comment to warn against updating the package version.

Should probably also be ported over to https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/blob/master/src/NServiceBus.AzureFunctions.SourceGenerator/NServiceBus.AzureFunctions.SourceGenerator.csproj