### PR TITLE
Fix UserProperties

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -3,7 +3,7 @@ namespace NServiceBus
 {
     public class FunctionEndpoint : NServiceBus.IFunctionEndpoint
     {
-        public System.Threading.Tasks.Task Process(byte[] body, System.Collections.Generic.IDictionary<string, string> userProperties, string messageId, int deliveryCount, string replyTo, string correlationId, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task Process(byte[] body, string messageId, int deliveryCount, string replyTo, string correlationId, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task Publish(object message, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken) { }
@@ -27,7 +27,7 @@ namespace NServiceBus
     }
     public interface IFunctionEndpoint
     {
-        System.Threading.Tasks.Task Process(byte[] body, System.Collections.Generic.IDictionary<string, string> userProperties, string messageId, int deliveryCount, string replyTo, string correlationId, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Process(byte[] body, string messageId, int deliveryCount, string replyTo, string correlationId, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish(object message, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Microsoft.Azure.Functions.Worker.FunctionContext functionContext, System.Threading.CancellationToken cancellationToken = default);

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FakeFunctionContext.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FakeFunctionContext.cs
@@ -8,12 +8,13 @@
 
     sealed class FakeFunctionContext : FunctionContext
     {
-        public FakeFunctionContext()
+        public FakeFunctionContext(IDictionary<string, string> userProperties = default) : base()
         {
             var sc = new ServiceCollection();
             sc.AddSingleton<ILoggerFactory>(new TestLoggingFactory());
 
             InstanceServices = sc.BuildServiceProvider();
+            BindingContext = new FakeBindingContext(userProperties);
         }
 
         public override string InvocationId { get; }
@@ -57,5 +58,17 @@
         {
             throw new NotImplementedException();
         }
+    }
+
+    class FakeBindingContext : BindingContext
+    {
+        public FakeBindingContext(IDictionary<string, string> userProperties)
+        {
+            BindingData = new Dictionary<string, object>
+            {
+                { "UserProperties", System.Text.Json.JsonSerializer.Serialize(userProperties ?? new Dictionary<string,string>())}
+        };
+        }
+        public override IReadOnlyDictionary<string, object> BindingData { get; }
     }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FakeFunctionContext.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FakeFunctionContext.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.Json;
     using Microsoft.Azure.Functions.Worker;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -66,7 +67,7 @@
         {
             BindingData = new Dictionary<string, object>
             {
-                { "UserProperties", System.Text.Json.JsonSerializer.Serialize(userProperties ?? new Dictionary<string,string>())}
+                { "UserProperties", JsonSerializer.Serialize(userProperties ?? new Dictionary<string,string>())}
         };
         }
         public override IReadOnlyDictionary<string, object> BindingData { get; }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -102,15 +102,13 @@
             {
                 foreach (var message in messages)
                 {
-                    var functionContext = new FakeFunctionContext();
                     await endpoint.Process(
                         MessageHelper.GetBody(message),
-                        MessageHelper.GetUserProperties(message),
                         Guid.NewGuid().ToString("N"),
                         1,
                         null,
                         string.Empty,
-                        functionContext,
+                        new FakeFunctionContext(MessageHelper.GetUserProperties(message)),
                         token);
                 }
             }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointTests.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointTests.cs
@@ -18,13 +18,13 @@
         {
             return FunctionEndpoint.Process(
                 MessageHelper.GetBody(message),
-                MessageHelper.GetUserProperties(message),
                 Guid.NewGuid().ToString("N"),
                 1,
                 null,
                 null,
                 transactionStrategy,
                 pipeline,
+                new FakeFunctionContext(),
                 CancellationToken.None);
         }
 
@@ -47,13 +47,13 @@
             var userProperties = MessageHelper.GetUserProperties(message);
             await FunctionEndpoint.Process(
                 body,
-                userProperties,
                 messageId,
                 1,
                 null,
                 null,
                 transactionStrategy,
                 pipelineInvoker,
+                new FakeFunctionContext(userProperties),
                 CancellationToken.None);
 
             Assert.IsTrue(transactionStrategy.OnCompleteCalled);
@@ -85,13 +85,13 @@
             var userProperties = MessageHelper.GetUserProperties(message);
             await FunctionEndpoint.Process(
                 body,
-                userProperties,
                 messageId,
                 1,
                 null,
                 null,
                 transactionStrategy,
                 pipelineInvoker,
+                new FakeFunctionContext(userProperties),
                 CancellationToken.None);
 
             Assert.AreSame(pipelineException, errorContext.Exception);

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
     using AzureFunctions.Worker.ServiceBus;
@@ -59,7 +60,7 @@
 
             if (functionContext.BindingContext.BindingData.TryGetValue("UserProperties", out var userPropertiesData))
             {
-                userProperties = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(userPropertiesData.ToString());
+                userProperties = JsonSerializer.Deserialize<Dictionary<string, string>>(userPropertiesData.ToString());
             }
 
             var headers = CreateNServiceBusHeaders(userProperties, replyTo, correlationId);

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/IFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/IFunctionEndpoint.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Functions.Worker;
@@ -17,7 +16,6 @@
         /// </summary>
         Task Process(
             byte[] body,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_override_trigger_function_name.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_override_trigger_function_name.approved.txt
@@ -17,13 +17,12 @@ public class FunctionEndpointTrigger
         [Function("trigger")]
         public async Task Run(
             [ServiceBusTrigger("endpoint")] byte[] messageBody,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,
             string correlationId,
             FunctionContext context)
         {
-            await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
+            await endpoint.Process(messageBody, messageId, deliveryCount, replyTo, correlationId, context);
         }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.NameIsStringValue.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.NameIsStringValue.approved.txt
@@ -17,13 +17,12 @@ public class FunctionEndpointTrigger
         [Function("NServiceBusFunctionEndpointTrigger-endpoint")]
         public async Task Run(
             [ServiceBusTrigger("endpoint")] byte[] messageBody,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,
             string correlationId,
             FunctionContext context)
         {
-            await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
+            await endpoint.Process(messageBody, messageId, deliveryCount, replyTo, correlationId, context);
         }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingFullyQualifiedAttributeName.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingFullyQualifiedAttributeName.approved.txt
@@ -17,13 +17,12 @@ public class FunctionEndpointTrigger
         [Function("NServiceBusFunctionEndpointTrigger-endpoint")]
         public async Task Run(
             [ServiceBusTrigger("endpoint")] byte[] messageBody,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,
             string correlationId,
             FunctionContext context)
         {
-            await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
+            await endpoint.Process(messageBody, messageId, deliveryCount, replyTo, correlationId, context);
         }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingNamespace.approved.txt
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingNamespace.approved.txt
@@ -17,13 +17,12 @@ public class FunctionEndpointTrigger
         [Function("NServiceBusFunctionEndpointTrigger-endpoint")]
         public async Task Run(
             [ServiceBusTrigger("endpoint")] byte[] messageBody,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,
             string correlationId,
             FunctionContext context)
         {
-            await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
+            await endpoint.Process(messageBody, messageId, deliveryCount, replyTo, correlationId, context);
         }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -111,13 +111,23 @@ public class FunctionEndpointTrigger
         [Function(""{syntaxReceiver.triggerFunctionName}"")]
         public async Task Run(
             [ServiceBusTrigger(""{syntaxReceiver.endpointName}"")] byte[] messageBody,
-            IDictionary<string, string> userProperties,
             string messageId,
             int deliveryCount,
             string replyTo,
             string correlationId,
             FunctionContext context)
         {{
+            Dictionary<string, string> userProperties;
+
+            if (context.BindingContext.BindingData.TryGetValue(""UserProperties"", out var userProperties) && userProperties != null)
+            {{
+                userProperties = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(userProperties.ToString());
+            }}
+            else
+            {{
+                userProperties = new Dictionary<string, string>();
+            }}
+
             await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
         }}
 }}";

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -117,18 +117,7 @@ public class FunctionEndpointTrigger
             string correlationId,
             FunctionContext context)
         {{
-            Dictionary<string, string> userProperties;
-
-            if (context.BindingContext.BindingData.TryGetValue(""UserProperties"", out var userProperties) && userProperties != null)
-            {{
-                userProperties = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(userProperties.ToString());
-            }}
-            else
-            {{
-                userProperties = new Dictionary<string, string>();
-            }}
-
-            await endpoint.Process(messageBody, userProperties, messageId, deliveryCount, replyTo, correlationId, context);
+            await endpoint.Process(messageBody, messageId, deliveryCount, replyTo, correlationId, context);
         }}
 }}";
             context.AddSource("NServiceBus__FunctionEndpointTrigger", SourceText.From(source, Encoding.UTF8));


### PR DESCRIPTION
Injecting `UserProperties` as a dictionary will fail if a function is throwing and retried.

Related to https://github.com/Particular/docs.particular.net/pull/5545