### PR TITLE
Add .NET Core 3.1 to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            3.1.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Install NuGetKeyVaultSignTool


### PR DESCRIPTION
The ManualTests.HostV3 project requires a .NET Core 3.1 runtime to build properly.