### PR TITLE
Remove GitVersion workaround

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,11 +1,7 @@
 <Project>
 
-    <PropertyGroup>
-        <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
+  <PropertyGroup>
+    <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
+  </PropertyGroup>
 
-        <!-- Disable GitVersion normalization for build agents to generate correct versions from tags -->
-        <!-- See https://github.com/GitTools/GitVersion/issues/2838 for further details -->
-        <GitVersion_NoNormalizeEnabled>true</GitVersion_NoNormalizeEnabled>
-    </PropertyGroup>
-    
 </Project>

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="[1.0.1, 2.0.0)" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[1.9.0, 2.0.0)" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[2.3.0, 3.0.0)" />
-    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/NServiceBus.AzureFunctions.Worker.SourceGenerator.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Workaround to make sure GitVersion uses the project specific config file -->


### PR DESCRIPTION
This removes the GitVersion workaround from the `release-1.0` branch that should no longer be required.