### PR TITLE
Adding dependancy to Test project for Dependabot

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests.csproj
@@ -12,6 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <!-- DO NOT REMOVE Microsoft.Azure.Functions.Worker, it is added so that dependabot knows about version changes-->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.4.0" />
+    <!-- DO NOT REMOVE Microsoft.Azure.Functions.Worker.Extensions.ServiceBus, it is added so that dependabot knows about version changes-->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />


### PR DESCRIPTION
Adding dependencies to the Test project so Dependabot will keep track of them and notify use of issues