### PR TITLE
Report error when using invalid binding expressions

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
@@ -62,6 +62,14 @@ namespace Foo
             Assert.True(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error && d.Id == TriggerFunctionGenerator.InvalidBindingExpression.Id));
         }
 
+        [Test]
+        public void Binding_expression_with_trigger_function_should_not_generate_error()
+        {
+            var source = @"[assembly: NServiceBus.NServiceBusTriggerFunction(""%ENDPOINT_NAME%"", TriggerFunctionName = ""trigger"")]";
+            var (_, diagnostics) = GetGeneratedOutput(source, suppressGeneratedDiagnosticsErrors: true);
+
+            Assert.False(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        }
 
         [Test]
         public void NameIsStringValue()

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
@@ -54,6 +54,17 @@ namespace Foo
         }
 
         [Test]
+        public void Endpoint_name_using_binding_expression_should_generate_compilation_error()
+        {
+            var source = @"[assembly: NServiceBus.NServiceBusTriggerFunction(""%ENDPOINT_NAME%"")]";
+            var (_, diagnostics) = GetGeneratedOutput(source, suppressGeneratedDiagnosticsErrors: true);
+
+            Assert.True(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error && d.Id == TriggerFunctionGenerator.InvalidBindingExpression.Id));
+
+        }
+
+
+        [Test]
         public void NameIsStringValue()
         {
             var source = @"[assembly: NServiceBus.NServiceBusTriggerFunction(""endpoint"")]";

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
@@ -54,7 +54,7 @@ namespace Foo
         }
 
         [Test]
-        public void Endpoint_name_using_binding_expression_should_generate_compilation_error()
+        public void Endpoint_name_using_binding_expression_should_generate_compilation_error_when_no_trigger_function_is_given()
         {
             var source = @"[assembly: NServiceBus.NServiceBusTriggerFunction(""%ENDPOINT_NAME%"")]";
             var (_, diagnostics) = GetGeneratedOutput(source, suppressGeneratedDiagnosticsErrors: true);

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator.Tests/SourceGeneratorApprovals.cs
@@ -60,7 +60,6 @@ namespace Foo
             var (_, diagnostics) = GetGeneratedOutput(source, suppressGeneratedDiagnosticsErrors: true);
 
             Assert.True(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error && d.Id == TriggerFunctionGenerator.InvalidBindingExpression.Id));
-
         }
 
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -75,7 +75,7 @@
                 bool IsNServiceBusEndpointNameAttribute(string value) => value?.Equals("NServiceBus.NServiceBusTriggerFunctionAttribute") ?? false;
                 string AttributeParameterAtPosition(int position) => context.SemanticModel.GetConstantValue(attributeSyntax.ArgumentList.Arguments[position].Expression).ToString();
                 int AttributeParametersCount() => attributeSyntax.ArgumentList.Arguments.Count;
-                bool IsBindingExpression(string endpointName) => endpointName != null && endpointName[0] == '%' && endpointName[0] == endpointName[endpointName.Length - 1]);
+                bool IsBindingExpression(string endpointName) => endpointName != null && endpointName[0] == '%' && endpointName[0] == endpointName[endpointName.Length - 1];
             }
         }
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -93,16 +93,17 @@
                 return;
             }
 
-            if (syntaxReceiver.isInvalidBindingExpression)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(InvalidBindingExpression, Location.None, syntaxReceiver.endpointName));
-                return;
-            }
-
             // Generate an error if empty/null/space is used as endpoint name
             if (string.IsNullOrWhiteSpace(syntaxReceiver.endpointName))
             {
                 context.ReportDiagnostic(Diagnostic.Create(InvalidEndpointNameError, Location.None, syntaxReceiver.endpointName));
+                return;
+            }
+
+            // Generate an error if a binding expression is provided with no trigger function name
+            if (syntaxReceiver.isInvalidBindingExpression)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidBindingExpression, Location.None, syntaxReceiver.endpointName));
                 return;
             }
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -75,7 +75,7 @@
                 bool IsNServiceBusEndpointNameAttribute(string value) => value?.Equals("NServiceBus.NServiceBusTriggerFunctionAttribute") ?? false;
                 string AttributeParameterAtPosition(int position) => context.SemanticModel.GetConstantValue(attributeSyntax.ArgumentList.Arguments[position].Expression).ToString();
                 int AttributeParametersCount() => attributeSyntax.ArgumentList.Arguments.Count;
-                bool IsBindingExpression(string endpointName) => endpointName[0] == endpointName[endpointName.Length - 1] && endpointName[0] == '%';
+                bool IsBindingExpression(string endpointName) => endpointName != null && endpointName[0] == '%' && endpointName[0] == endpointName[endpointName.Length - 1]);
             }
         }
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -75,7 +75,7 @@
                 bool IsNServiceBusEndpointNameAttribute(string value) => value?.Equals("NServiceBus.NServiceBusTriggerFunctionAttribute") ?? false;
                 string AttributeParameterAtPosition(int position) => context.SemanticModel.GetConstantValue(attributeSyntax.ArgumentList.Arguments[position].Expression).ToString();
                 int AttributeParametersCount() => attributeSyntax.ArgumentList.Arguments.Count;
-                bool IsBindingExpression(string endpointName) => endpointName != null && endpointName[0] == '%' && endpointName[0] == endpointName[endpointName.Length - 1];
+                bool IsBindingExpression(string endpointName) => !string.IsNullOrWhiteSpace(endpointName) && endpointName[0] == '%' && endpointName[0] == endpointName[endpointName.Length - 1];
             }
         }
 

--- a/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.SourceGenerator/TriggerFunctionGenerator.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.SourceGenerator
 {
+    using System;
     using System.Text;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -24,6 +25,15 @@
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        internal static readonly DiagnosticDescriptor InvalidBindingExpression = new DiagnosticDescriptor(
+            id: "NSBWFUNC 003",
+            title: "Invalid binding expression pattern use",
+            messageFormat: "Binding expression patterns require that a TriggerFunctionName be specified",
+            category: "TriggerFunctionGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+
         public void Initialize(GeneratorInitializationContext context)
         {
             context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
@@ -34,6 +44,7 @@
             internal string endpointName;
             internal string triggerFunctionName;
             internal bool attributeFound;
+            internal bool isInvalidBindingExpression = false;
 
             public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
             {
@@ -50,6 +61,10 @@
 
                     if (attributeParametersCount == 1)
                     {
+                        if (IsBindingExpression(endpointName))
+                        {
+                            isInvalidBindingExpression = true;
+                        }
                         return;
                     }
 
@@ -60,6 +75,7 @@
                 bool IsNServiceBusEndpointNameAttribute(string value) => value?.Equals("NServiceBus.NServiceBusTriggerFunctionAttribute") ?? false;
                 string AttributeParameterAtPosition(int position) => context.SemanticModel.GetConstantValue(attributeSyntax.ArgumentList.Arguments[position].Expression).ToString();
                 int AttributeParametersCount() => attributeSyntax.ArgumentList.Arguments.Count;
+                bool IsBindingExpression(string endpointName) => endpointName[0] == endpointName[endpointName.Length - 1] && endpointName[0] == '%';
             }
         }
 
@@ -74,6 +90,12 @@
             // Skip processing if no attribute was found
             if (!syntaxReceiver.attributeFound)
             {
+                return;
+            }
+
+            if (syntaxReceiver.isInvalidBindingExpression)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(InvalidBindingExpression, Location.None, syntaxReceiver.endpointName));
                 return;
             }
 


### PR DESCRIPTION
addresses https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/issues/151

generating a diagnostic error when there is no trigger function parameter being specified by the user and a binding expression is used for the endpoint name