### PR TITLE
Resolve endpoint name from binding expressions

### DIFF
--- a/src/ManualTests.HostV4/ManualTests.HostV4.csproj
+++ b/src/ManualTests.HostV4/ManualTests.HostV4.csproj
@@ -21,7 +21,8 @@
 
   <ItemGroup>
     <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
+    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest">
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/ManualTests.HostV4/Program.cs
+++ b/src/ManualTests.HostV4/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Hosting;
 using NServiceBus;
 
-[assembly: NServiceBusTriggerFunction("ManualTestsV4Host")]
+[assembly: NServiceBusTriggerFunction("%MY_ENDPOINT_NAME%", TriggerFunctionName = "MyFunctionName")]
 
 public class Program
 {
@@ -9,7 +9,7 @@ public class Program
     {
         var host = new HostBuilder()
             .ConfigureFunctionsWorkerDefaults()
-            .UseNServiceBus()
+            .UseNServiceBus("yolo3", (configuration, endpointConfiguration) => { })
             .Build();
 
         host.Run();

--- a/src/ManualTests.HostV4/Properties/launchSettings.json
+++ b/src/ManualTests.HostV4/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "ManualTests.HostV4": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ENV_ENDPOINT_NAME": "ValueFromEnvironmentVariable"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to #151

Currently, the endpoint name is either the value of an `ENDPOINT_NAME` configuration value (e.g. Environment variable) or the `NServiceBusTriggerFunctionAttribute.EndpointName` property. This hardcoded configuration value can be confusing when using binding expressions for the `NServiceBusTriggerFunctionAttribute`, e.g. using `[NServiceBusTriggerFunction("%ENDPOINT%", TriggerFunctionName="MyFunction"]`. In this case, the endpoint name will be `"%ENDPOINT%"` and not the actual value of the binding expression. This only works when using `%ENDPOINT_NAME%` as the binding expression since the binding expression value resolves to the same value the current logic is looking up and taking priority over the `"%ENDPOINT%"`  value.

With this change, the endpoint name resolving logic tries to resolve the configured endpoint name from the setting, so the user can define any value in the `NServiceBusTriggerFunction` attribute and provide the value via environment variables or app settings file. This way, the endpoint name and the binding for the queue trigger will use the same value even when the variable name is not `ENDPOINT_NAME`.

To maintain backwards compatibility, the  `ENDPOINT_NAME` environment variable is still taken into consideration with highest priority. To change to a binding expression that is not `%ENDPOINT_NAME%` for both the endpoint and the queue, the `ENDPOINT_NAME` env variable would have to be deleted.