### PR TITLE
Cleanup manual test host

### DIFF
--- a/src/ManualTests.HostV4/ManualTests.HostV4.csproj
+++ b/src/ManualTests.HostV4/ManualTests.HostV4.csproj
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest">
-    </None>
+    <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/ManualTests.HostV4/Program.cs
+++ b/src/ManualTests.HostV4/Program.cs
@@ -9,7 +9,7 @@ public class Program
     {
         var host = new HostBuilder()
             .ConfigureFunctionsWorkerDefaults()
-            .UseNServiceBus("yolo3", (configuration, endpointConfiguration) => { })
+            .UseNServiceBus()
             .Build();
 
         host.Run();

--- a/src/ManualTests.HostV4/Properties/launchSettings.json
+++ b/src/ManualTests.HostV4/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ManualTests.HostV4": {
       "commandName": "Project",
       "environmentVariables": {
-        "ENV_ENDPOINT_NAME": "ValueFromEnvironmentVariable"
+        "MY_ENDPOINT_NAME": "EndpointNameFromBindingExpression"
       }
     }
   }


### PR DESCRIPTION
There were some changes to the test host made in https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/pull/207 that shouldn't really have been committed. This PR cleans up the test host a bit (but keeps using binding expressions)