### PR TITLE
Defer serverless set up until after user customization applied

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -88,11 +88,13 @@
 
                 configurationCustomization(functionEndpointConfiguration);
 
+                var serverless = functionEndpointConfiguration.MakeServerless();
+
                 var serviceCollection = new ServiceCollection();
                 var startableEndpointWithExternallyManagedContainer = EndpointWithExternallyManagedContainer.Create(functionEndpointConfiguration.AdvancedConfiguration, serviceCollection);
                 var serviceProvider = serviceCollection.BuildServiceProvider();
 
-                endpoint = new FunctionEndpoint(startableEndpointWithExternallyManagedContainer, functionEndpointConfiguration, serviceProvider);
+                endpoint = new FunctionEndpoint(startableEndpointWithExternallyManagedContainer, serverless, serviceProvider);
 
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
@@ -16,9 +16,9 @@
     public class FunctionEndpoint : IFunctionEndpoint
     {
         // This ctor is used for the FunctionsHostBuilder scenario where the endpoint is created already during configuration time using the function host's container.
-        internal FunctionEndpoint(IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint, ServiceBusTriggeredEndpointConfiguration configuration, IServiceProvider serviceProvider)
+        internal FunctionEndpoint(IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint, ServerlessInterceptor serverless, IServiceProvider serviceProvider)
         {
-            this.configuration = configuration;
+            this.serverless = serverless;
             endpointFactory = _ => externallyManagedContainerEndpoint.Start(serviceProvider);
         }
 
@@ -117,7 +117,7 @@
                     {
                         endpoint = await endpointFactory(functionContext).ConfigureAwait(false);
 
-                        pipeline = configuration.PipelineInvoker;
+                        pipeline = serverless.PipelineInvoker;
                     }
                 }
                 finally
@@ -232,7 +232,7 @@
         readonly Func<FunctionContext, Task<IEndpointInstance>> endpointFactory;
 
         readonly SemaphoreSlim semaphoreLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
-        ServiceBusTriggeredEndpointConfiguration configuration;
+        readonly ServerlessInterceptor serverless;
 
         PipelineInvoker pipeline;
         IEndpointInstance endpoint;

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -109,6 +109,7 @@
 
                 var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(endpointName, configuration, connectionString);
                 configurationCustomization?.Invoke(configuration, functionEndpointConfiguration);
+                functionEndpointConfiguration.MakeServerless();
 
                 var endpointFactory = Configure(functionEndpointConfiguration, serviceCollection);
 
@@ -138,7 +139,9 @@
                     configuration.AdvancedConfiguration,
                     serviceCollection);
 
-            return serviceProvider => new FunctionEndpoint(startableEndpoint, configuration, serviceProvider);
+            var serverless = configuration.MakeServerless();
+
+            return serviceProvider => new FunctionEndpoint(startableEndpoint, serverless, serviceProvider);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -109,7 +109,6 @@
 
                 var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(endpointName, configuration, connectionString);
                 configurationCustomization?.Invoke(configuration, functionEndpointConfiguration);
-                functionEndpointConfiguration.MakeServerless();
 
                 var endpointFactory = Configure(functionEndpointConfiguration, serviceCollection);
 

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/ServerlessInterceptor.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/ServerlessInterceptor.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus;
+
+using AzureFunctions.Worker.ServiceBus;
+
+class ServerlessInterceptor
+{
+    readonly ServerlessTransport transport;
+
+    public ServerlessInterceptor(ServerlessTransport transport) => this.transport = transport;
+
+    public PipelineInvoker PipelineInvoker => transport.PipelineInvoker;
+}


### PR DESCRIPTION
Fixes #254 

Defers setting up the serverless infrastructure until after the user customization has been applied. After this change, it doesn't matter if `UseTransport(..)` is called, as that configuration is overwritten just before the endpoint is started.