### PR TITLE
Fix ServerlessTransport configuration

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -88,13 +88,11 @@
 
                 configurationCustomization(functionEndpointConfiguration);
 
-                var serverless = functionEndpointConfiguration.MakeServerless();
-
                 var serviceCollection = new ServiceCollection();
-                var startableEndpointWithExternallyManagedContainer = EndpointWithExternallyManagedContainer.Create(functionEndpointConfiguration.AdvancedConfiguration, serviceCollection);
-                var serviceProvider = serviceCollection.BuildServiceProvider();
+                var endpointFactory = functionEndpointConfiguration.CreateEndpointFactory(serviceCollection);
 
-                endpoint = new FunctionEndpoint(startableEndpointWithExternallyManagedContainer, serverless, serviceProvider);
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+                endpoint = endpointFactory(serviceProvider);
 
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionEndpoint.cs
@@ -15,7 +15,6 @@
     /// </summary>
     public class FunctionEndpoint : IFunctionEndpoint
     {
-        // This ctor is used for the FunctionsHostBuilder scenario where the endpoint is created already during configuration time using the function host's container.
         internal FunctionEndpoint(IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint, ServerlessInterceptor serverless, IServiceProvider serviceProvider)
         {
             this.serverless = serverless;

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -108,9 +108,10 @@
                 }
 
                 var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(endpointName, configuration, connectionString);
+
                 configurationCustomization?.Invoke(configuration, functionEndpointConfiguration);
 
-                var endpointFactory = Configure(functionEndpointConfiguration, serviceCollection);
+                var endpointFactory = functionEndpointConfiguration.CreateEndpointFactory(serviceCollection);
 
                 // for backward compatibility
                 serviceCollection.AddSingleton(endpointFactory);
@@ -128,19 +129,6 @@
             });
 
 
-        }
-
-        internal static Func<IServiceProvider, FunctionEndpoint> Configure(
-            ServiceBusTriggeredEndpointConfiguration configuration,
-            IServiceCollection serviceCollection)
-        {
-            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
-                    configuration.AdvancedConfiguration,
-                    serviceCollection);
-
-            var serverless = configuration.MakeServerless();
-
-            return serviceProvider => new FunctionEndpoint(startableEndpoint, serverless, serviceProvider);
         }
     }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -82,14 +82,14 @@
 
         internal Func<IServiceProvider, FunctionEndpoint> CreateEndpointFactory(IServiceCollection serviceCollection)
         {
-            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
-                AdvancedConfiguration,
-                serviceCollection);
-
             // Configure ServerlessTransport as late as possible to prevent users changing the transport configuration
             var serverlessTransport = new ServerlessTransport(Transport);
             AdvancedConfiguration.UseTransport(serverlessTransport);
             var serverless = new ServerlessInterceptor(serverlessTransport);
+
+            var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
+                AdvancedConfiguration,
+                serviceCollection);
 
             return serviceProvider => new FunctionEndpoint(startableEndpoint, serverless, serviceProvider);
         }


### PR DESCRIPTION
With https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/pull/255, the `ServerlessTransport` is configured via the `UseTransport` API after `EndpointWithExternallyManagedContainer.Create` has been called. This means the settings are locked and will throw on attempted changes, which will happen with calling `MakeServerless`, causing the endpoint to fail configuration and fail startup completely.

I've refactored the setup slightly to ensure that the acceptance test component uses the same configuration order as the functions host extension to reproduce the behavior.

Since this has been ported to the 4.1 branch, this should probably be fixed there too. I'm not quite sure about the behavior in the InProcess implementation at this point, it should be verified too.