### PR TITLE
Default to supported transaction mode

### DIFF
--- a/src/ManualTests.HostV4/ManualTests.HostV4.csproj
+++ b/src/ManualTests.HostV4/ManualTests.HostV4.csproj
@@ -17,8 +17,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.14.1" />
-    <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.0.0" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.1" />    
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ManualTests.HostV4/ManualTests.HostV4.csproj
+++ b/src/ManualTests.HostV4/ManualTests.HostV4.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.14.1" />
+    <PackageReference Include="NServiceBus.Persistence.NonDurable" Version="1.0.0" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.1" />    
   </ItemGroup>
 

--- a/src/ManualTests.HostV4/Program.cs
+++ b/src/ManualTests.HostV4/Program.cs
@@ -11,6 +11,9 @@ public class Program
             .ConfigureFunctionsWorkerDefaults()
             .UseNServiceBus(c =>
             {
+                c.AdvancedConfiguration.EnableOutbox();
+                c.AdvancedConfiguration.UsePersistence<NonDurablePersistence>();
+
                 //c.AdvancedConfiguration.SendOnly();
                 c.Routing.RouteToEndpoint(typeof(TriggerMessage), "some-queue");
                 c.AdvancedConfiguration.EnableInstallers();

--- a/src/ManualTests.HostV4/Program.cs
+++ b/src/ManualTests.HostV4/Program.cs
@@ -11,10 +11,6 @@ public class Program
             .ConfigureFunctionsWorkerDefaults()
             .UseNServiceBus(c =>
             {
-                c.AdvancedConfiguration.EnableOutbox();
-                c.AdvancedConfiguration.UsePersistence<NonDurablePersistence>();
-
-                //c.AdvancedConfiguration.SendOnly();
                 c.Routing.RouteToEndpoint(typeof(TriggerMessage), "some-queue");
                 c.AdvancedConfiguration.EnableInstallers();
             })

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/When_outbox_is_enabled.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus.Tests/When_outbox_is_enabled.cs
@@ -1,0 +1,59 @@
+﻿namespace ServiceBus.Tests
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_outbox_is_enabled
+    {
+        [Test]
+        public async Task Should_work()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithComponent(new OutboxEnabledFunction(new SomeMessage()))
+                .Done(c => c.GotTheMessage)
+                .Run();
+
+            Assert.True(context.GotTheMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+        }
+
+        class OutboxEnabledFunction : FunctionEndpointComponent
+        {
+            public OutboxEnabledFunction(object triggerMessage)
+            {
+                CustomizeConfiguration = configuration =>
+                {
+                    configuration.AdvancedConfiguration.UsePersistence<AcceptanceTestingPersistence>();
+                    configuration.AdvancedConfiguration.EnableOutbox();
+                };
+                AddTestMessage(triggerMessage);
+            }
+
+            public class SomeMessageHandler : IHandleMessages<SomeMessage>
+            {
+                Context testContext;
+
+                public SomeMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    testContext.GotTheMessage = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class SomeMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
@@ -14,7 +14,7 @@
         public IMessageProcessor MessageProcessor { get; private set; }
 
         public ServerlessTransport(TransportDefinition baseTransport) : base(
-            baseTransport.TransportTransactionMode,
+            TransportTransactionMode.ReceiveOnly,
             baseTransport.SupportsDelayedDelivery,
             baseTransport.SupportsPublishSubscribe,
             baseTransport.SupportsTTBR)


### PR DESCRIPTION
Since we're just passing the default mode from the transport we'll get atomic sends with receive and this will prevent the outbox from being used without the user having to workaround by setting the mode explicitly to `ReceiveOnly`

Note that receive only is the only supported mode at this time https://docs.particular.net/nservicebus/hosting/azure-functions-service-bus/#custom-triggers-transactions