### PR TITLE
Disable the SDK source generators

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.props
@@ -1,6 +1,12 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
+    <FunctionsEnableMetadataSourceGen>false</FunctionsEnableMetadataSourceGen>
+    <FunctionsEnableExecutorSourceGen>false</FunctionsEnableExecutorSourceGen>
+    <!-- The property below is set to make sure the metadata source generator is actually disabled. 
+    This is needed due to a bug in the targets file and can be removed once 
+    https://github.com/Azure/azure-functions-dotnet-worker/issues/2209 is resolved
+    -->
     <FunctionsEnableWorkerIndexing>false</FunctionsEnableWorkerIndexing>
   </PropertyGroup>
 


### PR DESCRIPTION
The change introduced in #436 was not enough to get everything working correctly. We instead need to fully disable the SDK source generators:

```xml
 <FunctionsEnableMetadataSourceGen>false</FunctionsEnableMetadataSourceGen>
 <FunctionsEnableExecutorSourceGen>false</FunctionsEnableExecutorSourceGen>
```

However, as mentioned in https://github.com/Azure/azure-functions-dotnet-worker/issues/2209, disabling the metadata source generator is tied to the `FunctionsEnableWorkerIndexing` property. Until these are decoupled we have to also set `FunctionsEnableWorkerIndexing` to false.