### PR TITLE
Add Rosyln Analyser for LogDiagnostics

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.Analyzer.Tests/ConfigurationAnalyzerTests.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.Analyzer.Tests/ConfigurationAnalyzerTests.cs
@@ -70,4 +70,44 @@ class Foo
 
         return Assert(diagnosticId, source);
     }
+
+    [Test]
+    public Task DiagnosticIsReportedForLogDiagnostics()
+    {
+        var source =
+            @"using NServiceBus;
+using System;
+class Foo
+{
+    void Bar(ServiceBusTriggeredEndpointConfiguration endpointConfig)
+    {
+        [|endpointConfig.LogDiagnostics()|];
+    }
+}";
+
+        return Assert(LogDiagnosticsNotRecommendedId, source);
+    }
+
+    [Test]
+    public Task DiagnosticIsNotReportedForLogDiagnosticsOnOtherClass()
+    {
+        var source =
+            @"using NServiceBus;
+using System;
+
+class SomeOtherClass
+{
+    internal void LogDiagnostics() { }
+}
+
+class Foo
+{
+    void Bar(SomeOtherClass otherClass)
+    {
+        otherClass.LogDiagnostics();
+    }
+}";
+
+        return Assert(LogDiagnosticsNotRecommendedId, source);
+    }
 }

--- a/src/NServiceBus.AzureFunctions.Worker.Analyzer/AzureFunctionsDiagnostics.cs
+++ b/src/NServiceBus.AzureFunctions.Worker.Analyzer/AzureFunctionsDiagnostics.cs
@@ -21,6 +21,7 @@
         public const string PrefetchCountNotAllowedId = "NSBWFUNC015";
         public const string PrefetchMultiplierNotAllowedId = "NSBWFUNC016";
         public const string TimeToWaitBeforeTriggeringCircuitBreakerNotAllowedId = "NSBWFUNC017";
+        public const string LogDiagnosticsNotRecommendedId = "NSBWFUNC018";
 
         const string DiagnosticCategory = "NServiceBus.AzureFunctions";
 
@@ -172,6 +173,17 @@
              category: DiagnosticCategory,
              defaultSeverity: DiagnosticSeverity.Error,
              isEnabledByDefault: true
+            );
+
+        internal static readonly DiagnosticDescriptor LogDiagnosticsNotRecommended = new DiagnosticDescriptor(
+             id: LogDiagnosticsNotRecommendedId,
+             title: "LogDiagnostics is not recommended",
+             messageFormat: "Use 'AdvancedConfiguration.CustomDiagnosticsWriter' for more control over diagnostics output.",
+             category: DiagnosticCategory,
+             defaultSeverity: DiagnosticSeverity.Warning,
+             isEnabledByDefault: true,
+             description: "'LogDiagnostics()' in Azure Functions only outputs to the console and will not create a diagnostics file. Use 'AdvancedConfiguration.CustomDiagnosticsWriter' instead for full control over how and where diagnostics information is written.",
+             helpLinkUri: "https://docs.particular.net/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics"
             );
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/Particular/docs.particular.net/issues/5502

A rosyln analyser will warn users when using `LogDiagnostics` as this will only log the endpoints diagnostics to the console via `LogManager`. The analyzer will recommend to use `AdvancedConfiguration.CustomDiagnosticsWriter` and point the users to [docs ](https://docs.particular.net/nservicebus/hosting/azure-functions-service-bus/#configuration-custom-diagnostics) for further instructions for routing the diagnostics file to either Azure BLOB Storage or Azure Application Insights.