### PR TITLE
Fix analyzer package path to match referenced version

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.Analyzer/NServiceBus.AzureFunctions.Worker.Analyzer.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.Analyzer/NServiceBus.AzureFunctions.Worker.Analyzer.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
+    <!-- When this version changes, the package path in the main project also needs to be updated -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\NServiceBus.AzureFunctions.Worker.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Worker.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/NServiceBus.AzureFunctions.Worker.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.AzureFunctions.Worker.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Worker.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/NServiceBus.AzureFunctions.Worker.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddPropsFileToPackage">


### PR DESCRIPTION
Follow-up to #730

When the `Microsoft.CodeAnalysis.CSharp` package is updated, the package path of the analyzer assembly also needs to be updated.

I've added a comment to make sure this doesn't get overlooked next time.