### PR TITLE
Use property to control assembly package path

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
+    <RoslynPackageVersion>5.0.0</RoslynPackageVersion>
+    <RoslynPackagePathVersion>$(RoslynPackageVersion.Split(`.`)[0]).$(RoslynPackageVersion.Split(`.`)[1])</RoslynPackagePathVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <MinVerMinimumMajorMinor>7.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>

--- a/src/NServiceBus.AzureFunctions.Worker.Analyzer.Tests/NServiceBus.AzureFunctions.Worker.Analyzer.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.Analyzer.Tests/NServiceBus.AzureFunctions.Worker.Analyzer.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/NServiceBus.AzureFunctions.Worker.Analyzer/NServiceBus.AzureFunctions.Worker.Analyzer.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.Analyzer/NServiceBus.AzureFunctions.Worker.Analyzer.csproj
@@ -12,9 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
-    <!-- When this version changes, the package path in the main project also needs to be updated -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\NServiceBus.AzureFunctions.Worker.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Worker.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn5.0/cs/NServiceBus.AzureFunctions.Worker.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.AzureFunctions.Worker.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AzureFunctions.Worker.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.AzureFunctions.Worker.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddPropsFileToPackage">


### PR DESCRIPTION
This PR introduces properties to control the version of the Microsoft.CodeAnalysis packages and to calculate the resulting package path for the analyzer assemblies.