### PR TITLE
AsyncEnumerable ambiguity causes build errors on .NET 10

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
-    <PackageReference Include="NServiceBus" Version="8.2.4" />
+    <PackageReference Include="NServiceBus" Version="8.2.6" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.7" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fixes #755