### PR TITLE
Update dependency NServiceBus.Transport.AzureServiceBus to 6.2.2 (#777)

### DIFF
--- a/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.Worker.ServiceBus/NServiceBus.AzureFunctions.Worker.ServiceBus.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
-    <PackageReference Include="NServiceBus" Version="10.1.0" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="6.1.0" />
+    <PackageReference Include="NServiceBus" Version="10.1.3" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Downstream of the [NServiceBus.Transport.AzureServiceBus 6.2.2 release](https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/releases/tag/6.2.2)

Backport of:

- https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/pull/777

Which fixes for the https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/tree/release-7.1 branch:

- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1369
- https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/issues/1375
- https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/issues/795
- https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/issues/796